### PR TITLE
Make GitHub detect *.txt as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.txt linguist-language=Forth
+license.txt linguist-language=Text
+install.txt linguist-language=Text
+readme.txt linguist-language=Text
+ug.txt linguist-language=Text
+words.txt linguist-language=Text


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect the `.txt` files as Forth.

Thanks!
